### PR TITLE
chore: remove unused export output configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "export",
 };
 
 export default nextConfig;


### PR DESCRIPTION
- cleans up next.js configuration by removing the unused 'output' property